### PR TITLE
Fix TaskRouter streams

### DIFF
--- a/tap_twilio/streams.py
+++ b/tap_twilio/streams.py
@@ -376,7 +376,7 @@ STREAMS = {
                 'api_url': 'https://taskrouter.twilio.com',
                 'api_version': 'v1',
                 'path': 'Workspaces/{ParentId}/TaskChannels',
-                'data_key': 'task_channels',
+                'data_key': 'channels',
                 'key_properties': ['sid'],
                 'replication_method': 'INCREMENTAL',
                 'replication_keys': ['date_updated'],
@@ -431,8 +431,7 @@ STREAMS = {
                         'path': 'Workspaces/{ParentId}/Workers/{ParentId}/Channels',
                         'data_key': 'channels',
                         'key_properties': ["sid"],
-                        'replication_method': 'INCREMENTAL',
-                        'replication_keys': ['date_updated'],
+                        'replication_method': 'FULL_TABLE',
                         'params': {},
                         'pagination': 'root'
                     }
@@ -450,9 +449,9 @@ STREAMS = {
                 'replication_keys': ['date_updated'],
                 'params': {},
                 'pagination': 'root',
-            },
-        },
-    },
+            }
+        }
+    }
 }
 
 

--- a/tap_twilio/sync.py
+++ b/tap_twilio/sync.py
@@ -323,8 +323,13 @@ def sync_endpoint(
                             # their endpoints will be in the results,
                             # this will grab the child path for the child stream we're syncing,
                             # if we're syncing it. If it doesn't exist we just skip it below.
-                            child_path = record.get('_subresource_uris', record.get('links', {}))\
-                                .get(child_stream_name, None)
+                            child_paths = record.get('_subresource_uris', record.get('links', {}))
+
+                            # For some resources, the name of the stream is the key for the child_paths
+                            # but for others', the data_key contains the correct key
+                            child_path = child_paths.get(child_stream_name,
+                                                         child_paths.get(child_endpoint_config.get('data_key', None)))
+
                             child_bookmark_field = next(iter(child_endpoint_config.get(
                                 'replication_keys', [])), None)
 


### PR DESCRIPTION
replicate all the worker channels

## Problem

- `TaskChannels` wasn't syncing, because the key in the JSON response was `channels`
- Worker `Channels` weren't all synching

## Proposed changes

- `data_key` for `TaskChannels` to `channels` and modify the synching logic to use `data_key` also when figuring out the link for the stream
- Worker `Channels` need to be `FULL_TABLE` replicated, otherwise a bookmark will be stored for the parent stream, and they also won't be synched


## Types of changes

What types of changes does your code introduce to PipelineWise?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions