### PR TITLE
Fix UsageRecords and UsageTriggers support

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ This tap:
   - [conference_participants](https://www.twilio.com/docs/voice/api/conference-participant-resource#read-multiple-participant-resources)
   - [outgoing_caller_ids](https://www.twilio.com/docs/voice/api/outgoing-caller-ids#outgoingcallerids-list-resource)
   - [recordings](https://www.twilio.com/docs/voice/api/recording#read-multiple-recording-resources)
+  - [usage_records](https://www.twilio.com/docs/usage/api/usage-record#read-multiple-usagerecord-resources)
+  - [usage_triggers](https://www.twilio.com/docs/usage/api/usage-trigger#read-multiple-usagetrigger-resources)
   - [transcriptions](https://www.twilio.com/docs/voice/api/recording-transcription?code-sample=code-read-list-all-transcriptions&code-language=curl&code-sdk-version=json#read-multiple-transcription-resources)
   - [queues](https://www.twilio.com/docs/voice/api/queue-resource#read-multiple-queue-resources)
   - [message_media](https://www.twilio.com/docs/sms/api/media-resource#read-multiple-media-resources)
@@ -48,10 +50,6 @@ This tap:
   - [members](https://www.twilio.com/docs/chat/rest/member-resource?code-sample=code-read-multiple-member-resources)
   - [chat_messages](https://www.twilio.com/docs/chat/rest/message-resource#read-multiple-message-resources)
   - [users](https://www.twilio.com/docs/chat/rest/user-resource#read-multiple-user-resources)
- 
-- Has logic to extract the following data, but cannot, because these resources are 1 level deeper:
-  - [usage_records](https://www.twilio.com/docs/usage/api/usage-record#read-multiple-usagerecord-resources)
-  - [usage_triggers](https://www.twilio.com/docs/usage/api/usage-trigger#read-multiple-usagetrigger-resources)
  
 - Outputs the schema for each resource
 - Incrementally pulls data based on the input state

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setup(name='pipelinewise-tap-twilio',
-      version='1.0.0',
+      version='1.0.1',
       description='Singer.io tap for extracting data from the Twilio API - PipelineWise compatible',
       author='TransferWise',
       url='https://github.com/transferwise/pipelinewise-tap-twilio',

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setup(name='pipelinewise-tap-twilio',
-      version='1.0.1',
+      version='1.0.0',
       description='Singer.io tap for extracting data from the Twilio API - PipelineWise compatible',
       author='TransferWise',
       url='https://github.com/transferwise/pipelinewise-tap-twilio',

--- a/tap_twilio/schemas/usage.json
+++ b/tap_twilio/schemas/usage.json
@@ -1,0 +1,94 @@
+{
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "subresource_uris": {
+      "anyOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": [
+              "null",
+              "object"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "subresource": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "uri": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "type": "null"
+        },
+        {
+          "type": [
+            "null",
+            "object"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "yesterday": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "all_time": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "today": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "yearly": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "this_month": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "monthly": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "daily": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "last_month": {
+              "type": [
+                "null",
+                "string"
+              ]
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/tap_twilio/streams.py
+++ b/tap_twilio/streams.py
@@ -350,7 +350,7 @@ STREAMS = {
         'replication_method': 'INCREMENTAL',
         'replication_keys': ['date_updated'],
         'params': {},
-        'pagination': 'root',
+        'pagination': 'meta',
         'children': {
             # pylint: disable=line-too-long
             # Reference: https://www.twilio.com/docs/taskrouter/api/activity#read-multiple-activity-resources
@@ -363,7 +363,7 @@ STREAMS = {
                 'replication_method': 'INCREMENTAL',
                 'replication_keys': ['date_updated'],
                 'params': {},
-                'pagination': 'root',
+                'pagination': 'meta',
             },
             # pylint: disable=line-too-long
             # Reference: https://www.twilio.com/docs/taskrouter/api/event#list-all-events
@@ -376,7 +376,7 @@ STREAMS = {
                 'replication_method': 'INCREMENTAL',
                 'replication_keys': ['event_date'],
                 'params': {},
-                'pagination': 'root',
+                'pagination': 'meta',
             },
             # pylint: disable=line-too-long
             # Reference: https://www.twilio.com/docs/taskrouter/api/task#read-multiple-task-resources
@@ -389,7 +389,7 @@ STREAMS = {
                 'replication_method': 'INCREMENTAL',
                 'replication_keys': ['date_updated'],
                 'params': {},
-                'pagination': 'root',
+                'pagination': 'meta',
             },
             # pylint: disable=line-too-long
             # Reference: https://www.twilio.com/docs/taskrouter/api/task-channel#read-multiple-taskchannel-resources
@@ -402,7 +402,7 @@ STREAMS = {
                 'replication_method': 'INCREMENTAL',
                 'replication_keys': ['date_updated'],
                 'params': {},
-                'pagination': 'root',
+                'pagination': 'meta',
             },
             # pylint: disable=line-too-long
             # Reference: https://www.twilio.com/docs/taskrouter/api/task-queue#action-list
@@ -415,7 +415,7 @@ STREAMS = {
                 'replication_method': 'INCREMENTAL',
                 'replication_keys': ['date_updated'],
                 'params': {},
-                'pagination': 'root',
+                'pagination': 'meta',
                 'children': {
                     # pylint: disable=line-too-long
                     # Reference: https://www.twilio.com/docs/taskrouter/api/taskqueue-statistics#taskqueue-cumulative-statistics
@@ -427,7 +427,7 @@ STREAMS = {
                         'key_properties': [],
                         'replication_method': 'FULL_TABLE',
                         'params': {},
-                        'pagination': 'root'
+                        'pagination': 'meta'
                     }
                 }
             },
@@ -442,7 +442,7 @@ STREAMS = {
                 'replication_method': 'INCREMENTAL',
                 'replication_keys': ['date_updated'],
                 'params': {},
-                'pagination': 'root',
+                'pagination': 'meta',
                 'children': {
                     # pylint: disable=line-too-long
                     # Reference: https://www.twilio.com/docs/taskrouter/api/worker-channel#read-multiple-workerchannel-resources
@@ -454,7 +454,7 @@ STREAMS = {
                         'key_properties': ["sid"],
                         'replication_method': 'FULL_TABLE',
                         'params': {},
-                        'pagination': 'root'
+                        'pagination': 'meta'
                     }
                 }
             },
@@ -469,7 +469,7 @@ STREAMS = {
                 'replication_method': 'INCREMENTAL',
                 'replication_keys': ['date_updated'],
                 'params': {},
-                'pagination': 'root',
+                'pagination': 'meta',
             },
         },
     },
@@ -484,7 +484,7 @@ STREAMS = {
         'replication_method': 'INCREMENTAL',
         'replication_keys': ['date_updated'],
         'params': {},
-        'pagination': 'root',
+        'pagination': 'meta',
         'children': {
             # pylint: disable=line-too-long
             # Reference: https://www.twilio.com/docs/chat/rest/role-resource#read-multiple-role-resources
@@ -497,7 +497,7 @@ STREAMS = {
                 'replication_method': 'INCREMENTAL',
                 'replication_keys': ['date_updated'],
                 'params': {},
-                'pagination': 'root'
+                'pagination': 'meta'
             },
             # pylint: disable=line-too-long
             # Reference: https://www.twilio.com/docs/chat/rest/channel-resource#read-multiple-channel-resources
@@ -510,7 +510,7 @@ STREAMS = {
                 'replication_method': 'INCREMENTAL',
                 'replication_keys': ['date_updated'],
                 'params': {},
-                'pagination': 'root',
+                'pagination': 'meta',
                 'children': {
                     # pylint: disable=line-too-long
                     # Reference: https://www.twilio.com/docs/chat/rest/member-resource?code-sample=code-read-multiple-member-resources
@@ -522,7 +522,7 @@ STREAMS = {
                         'key_properties': ['sid'],
                         'replication_method': 'FULL_TABLE',
                         'params': {},
-                        'pagination': 'root'
+                        'pagination': 'meta'
                     },
                     # pylint: disable=line-too-long
                     # Reference: https://www.twilio.com/docs/chat/rest/message-resource#read-multiple-message-resources
@@ -534,7 +534,7 @@ STREAMS = {
                         'key_properties': ['sid'],
                         'replication_method': 'FULL_TABLE',
                         'params': {},
-                        'pagination': 'root'
+                        'pagination': 'meta'
                     }
                 }
             },
@@ -549,7 +549,7 @@ STREAMS = {
                 'replication_method': 'INCREMENTAL',
                 'replication_keys': ['date_updated'],
                 'params': {},
-                'pagination': 'root'
+                'pagination': 'meta'
             }
         }
     }

--- a/tap_twilio/streams.py
+++ b/tap_twilio/streams.py
@@ -557,8 +557,6 @@ STREAMS = {
 
 
 # De-nest children nodes for Discovery mode
-
-
 def flatten_streams():
     flat_streams = {}
     # Loop through parents

--- a/tap_twilio/streams.py
+++ b/tap_twilio/streams.py
@@ -8,10 +8,13 @@
 #        and setting the state
 #   params: Query, sort, and other endpoint specific parameters
 #   data_key: JSON element containing the records for the endpoint
+#   parent_subresource_key: key for this resource in the parent subresource_uri list (defaults to data_key if not set)
 #   bookmark_query_field: Typically a date-time field used for filtering the query
 #   bookmark_type: Data type for bookmark, integer or datetime
 #   children: A collection of child endpoints (where the endpoint path includes the parent id)
 #   parent: On each of the children, the singular stream name for parent element
+
+
 STREAMS = {
     # Reference: https://www.twilio.com/docs/usage/api/account#read-multiple-account-resources
     'accounts': {
@@ -23,7 +26,7 @@ STREAMS = {
         'replication_method': 'FULL_TABLE',  # Fetch ALL, filter results
         'replication_keys': ['date_updated'],
         'params': {},
-        'pagingation': 'root',
+        'pagination': 'root',
         'children': {
             # pylint: disable=line-too-long
             # Reference: https://www.twilio.com/docs/usage/api/address#read-multiple-address-resources
@@ -36,7 +39,7 @@ STREAMS = {
                 'replication_method': 'INCREMENTAL',  # Fetch ALL, filter results
                 'replication_keys': ['date_updated'],
                 'params': {},
-                'pagingation': 'root',
+                'pagination': 'root',
                 'children': {
                     # pylint: disable=line-too-long
                     # Reference: https://www.twilio.com/docs/usage/api/address?code-sample=code-list-dependent-pns-subresources&code-language=curl&code-sdk-version=json#instance-subresources
@@ -48,7 +51,7 @@ STREAMS = {
                         'key_properties': ['sid'],
                         'replication_method': 'FULL_TABLE',  # ALL for parent Address
                         'params': {},
-                        'pagingation': 'root',
+                        'pagination': 'root',
                         'parent': 'address'
                     }
                 }
@@ -64,7 +67,7 @@ STREAMS = {
                 'replication_method': 'INCREMENTAL',  # Fetch ALL, filter results
                 'replication_keys': ['date_updated'],
                 'params': {},
-                'pagingation': 'root'
+                'pagination': 'root'
             },
             # pylint: disable=line-too-long
             # Reference: https://www.twilio.com/docs/phone-numbers/api/availablephonenumber-resource#read-a-list-of-countries
@@ -76,7 +79,7 @@ STREAMS = {
                 'key_properties': ['country_code'],
                 'replication_method': 'FULL_TABLE',
                 'params': {},
-                'pagingation': 'none',
+                'pagination': 'none',
                 'children': {
                     # pylint: disable=line-too-long
                     # Reference: https://www.twilio.com/docs/phone-numbers/api/availablephonenumberlocal-resource#read-multiple-availablephonenumberlocal-resources
@@ -88,7 +91,7 @@ STREAMS = {
                         'key_properties': ['iso_country', 'phone_number'],
                         'replication_method': 'FULL_TABLE',  # ALL for parent Address
                         'params': {},
-                        'pagingation': 'root',
+                        'pagination': 'root',
                         'activate_version': True
                     },
                     # pylint: disable=line-too-long
@@ -101,7 +104,7 @@ STREAMS = {
                         'key_properties': ['iso_country', 'phone_number'],
                         'replication_method': 'FULL_TABLE',  # ALL for parent Address
                         'params': {},
-                        'pagingation': 'root',
+                        'pagination': 'root',
                         'activate_version': True
                     },
                     # pylint: disable=line-too-long
@@ -114,7 +117,7 @@ STREAMS = {
                         'key_properties': ['iso_country', 'phone_number'],
                         'replication_method': 'FULL_TABLE',  # ALL for parent Address
                         'params': {},
-                        'pagingation': 'root',
+                        'pagination': 'root',
                         'activate_version': True
                     }
                 }
@@ -130,7 +133,7 @@ STREAMS = {
                 'replication_method': 'INCREMENTAL',  # Fetch ALL, filter results
                 'replication_keys': ['date_updated'],
                 'params': {},
-                'pagingation': 'none'
+                'pagination': 'none'
             },
             # Reference: https://www.twilio.com/docs/usage/api/keys#read-a-key-resource
             'keys': {
@@ -142,7 +145,7 @@ STREAMS = {
                 'replication_method': 'INCREMENTAL',  # Fetch ALL, filter results
                 'replication_keys': ['date_updated'],
                 'params': {},
-                'pagingation': 'root'
+                'pagination': 'root'
             },
             # pylint: disable=line-too-long
             # Reference: https://www.twilio.com/docs/sms/api/message-resource#read-multiple-message-resources
@@ -157,7 +160,7 @@ STREAMS = {
                 'bookmark_query_field_from': 'EndTime>',  # Daily
                 'bookmark_query_field_to': 'EndTime<',
                 'params': {},
-                'pagingation': 'root'
+                'pagination': 'root'
             },
             # pylint: disable=line-too-long
             # Reference: https://www.twilio.com/docs/voice/api/conference-resource#read-multiple-conference-resources
@@ -172,7 +175,7 @@ STREAMS = {
                 'bookmark_query_field_from': 'DateUpdated>',  # Daily
                 'bookmark_query_field_to': 'DateUpdated<',
                 'params': {},
-                'pagingation': 'root',
+                'pagination': 'root',
                 'children': {
                     # pylint: disable=line-too-long
                     # Reference: https://www.twilio.com/docs/voice/api/conference-participant-resource#read-multiple-participant-resources
@@ -184,7 +187,7 @@ STREAMS = {
                         'key_properties': ['uri'],
                         'replication_method': 'FULL_TABLE',  # ALL for parent Conference
                         'params': {},
-                        'pagingation': 'root'
+                        'pagination': 'root'
                     }
                 }
             },
@@ -199,7 +202,7 @@ STREAMS = {
                 'replication_method': 'INCREMENTAL',  # Fetch ALL, filter results
                 'replication_keys': ['date_updated'],
                 'params': {},
-                'pagingation': 'none'
+                'pagination': 'none'
             },
             # pylint: disable=line-too-long
             # Reference: https://www.twilio.com/docs/voice/api/recording#read-multiple-recording-resources
@@ -214,7 +217,7 @@ STREAMS = {
                 'bookmark_query_field_from': 'DateCreated>',  # Daily
                 'bookmark_query_field_to': 'DateCreated<',
                 'params': {},
-                'pagingation': 'root'
+                'pagination': 'root'
             },
             # pylint: disable=line-too-long
             # Reference: https://www.twilio.com/docs/voice/api/recording-transcription?code-sample=code-read-list-all-transcriptions&code-language=curl&code-sdk-version=json#read-multiple-transcription-resources
@@ -227,7 +230,7 @@ STREAMS = {
                 'replication_method': 'INCREMENTAL',  # Fetch ALL, filter results
                 'replication_keys': ['date_updated'],
                 'params': {},
-                'pagingation': 'root'
+                'pagination': 'root'
             },
             # pylint: disable=line-too-long
             # Reference: https://www.twilio.com/docs/voice/api/queue-resource#read-multiple-queue-resources
@@ -240,7 +243,7 @@ STREAMS = {
                 'replication_method': 'INCREMENTAL',  # Fetch ALL, filter results
                 'replication_keys': ['date_updated'],
                 'params': {},
-                'pagingation': 'root'
+                'pagination': 'root'
             },
             # pylint: disable=line-too-long
             # Reference: https://www.twilio.com/docs/sms/api/message-resource#read-multiple-message-resources
@@ -255,7 +258,7 @@ STREAMS = {
                 'bookmark_query_field_from': 'DateSent>',  # Daily
                 'bookmark_query_field_to': 'DateSent<',
                 'params': {},
-                'pagingation': 'root',
+                'pagination': 'root',
                 'children': {
                     # pylint: disable=line-too-long
                     # Reference: https://www.twilio.com/docs/sms/api/media-resource#read-multiple-media-resources
@@ -267,39 +270,57 @@ STREAMS = {
                         'key_properties': ['sid'],
                         'replication_method': 'FULL_TABLE',  # ALL for parent Address
                         'params': {},
-                        'pagingation': 'root'
+                        'pagination': 'root'
                     }
                 }
             },
             # pylint: disable=line-too-long
             # Reference: https://www.twilio.com/docs/usage/api/usage-record#read-multiple-usagerecord-resources
-            'usage_records': {
+            'usage': {
                 'api_url': 'https://api.twilio.com',
                 'api_version': '2010-04-01',
-                'path': 'Accounts/{ParentId}/Usage/Records.json',
-                'data_key': 'usage_records',
-                'key_properties': ['account_sid', 'category', 'start_date'],
+                'path': 'Accounts/{ParentId}/Usage.json',
+                'data_key': '',
+                'key_properties': [''],
                 'replication_method': 'INCREMENTAL',  # Filter query
                 'replication_keys': ['end_date'],
                 'bookmark_query_field_from': 'StartDate',  # Daily
                 'bookmark_query_field_to': 'EndDate',
                 'params': {},
-                'pagingation': 'root'
-            },
-            # pylint: disable=line-too-long
-            # Reference: https://www.twilio.com/docs/usage/api/usage-trigger#read-multiple-usagetrigger-resources
-            'usage_triggers': {
-                'api_url': 'https://api.twilio.com',
-                'api_version': '2010-04-01',
-                'path': 'Accounts/{ParentId}/Usage/Triggers.json',
-                'data_key': 'usage_triggers',
-                'key_properties': ['sid'],
-                'replication_method': 'INCREMENTAL',  # Fetch ALL, filter results
-                'replication_keys': ['date_updated'],
-                'params': {},
-                'pagingation': 'root'
-            },
-
+                'pagination': 'root',
+                'children': {
+                    # pylint: disable=line-too-long
+                    # Reference: https://www.twilio.com/docs/usage/api/usage-record#read-multiple-usagerecord-resources
+                    'usage_records': {
+                        'api_url': 'https://api.twilio.com',
+                        'api_version': '2010-04-01',
+                        'path': 'Accounts/{AccountSid}/Usage/Records.json',
+                        'data_key': 'usage_records',
+                        'parent_subresource_key': 'records',
+                        'key_properties': ['account_sid', 'category', 'start_date'],
+                        'replication_method': 'INCREMENTAL',  # Filter query
+                        'replication_keys': ['end_date'],
+                        'bookmark_query_field_from': 'StartDate',  # Daily
+                        'bookmark_query_field_to': 'EndDate',
+                        'params': {},
+                        'pagination': 'root',
+                    },
+                    # pylint: disable=line-too-long
+                    # Reference: https://www.twilio.com/docs/usage/api/usage-trigger#read-multiple-usagetrigger-resources
+                    'usage_triggers': {
+                        'api_url': 'https://api.twilio.com',
+                        'api_version': '2010-04-01',
+                        'path': 'Accounts/{ParentId}/Usage/Triggers.json',
+                        'data_key': 'usage_triggers',
+                        'parent_subresource_key': 'triggers',
+                        'key_properties': ['sid'],
+                        'replication_method': 'INCREMENTAL',  # Fetch ALL, filter results
+                        'replication_keys': ['date_updated'],
+                        'params': {},
+                        'pagination': 'root'
+                    },
+                }
+            }
         }
     },
     # pylint: disable=line-too-long
@@ -316,7 +337,7 @@ STREAMS = {
         'bookmark_query_field_to': 'EndDate',  # Current Date
         'max_days_ago': 30,
         'params': {},
-        'pagingation': 'meta'
+        'pagination': 'meta'
     },
     # pylint: disable=line-too-long
     # Reference: https://www.twilio.com/docs/taskrouter/api/workspace#list-all-workspaces
@@ -536,6 +557,8 @@ STREAMS = {
 
 
 # De-nest children nodes for Discovery mode
+
+
 def flatten_streams():
     flat_streams = {}
     # Loop through parents

--- a/tap_twilio/sync.py
+++ b/tap_twilio/sync.py
@@ -251,7 +251,10 @@ def sync_endpoint(
                 break  # No data results
 
             # Get pagination details
-            next_url = data.get('meta', {}).get('next_page_url')
+            next_url = data.get('meta', {}).get('next_page_url') if endpoint_config.get("pagination") == "meta" else data.get('next_page_uri')
+            if next_url and not next_url.startswith('http'):
+                next_url = '{}{}'.format(endpoint_config.get('api_url'), next_url)
+
             api_total = 0
 
             if not data or data is None:
@@ -330,8 +333,10 @@ def sync_endpoint(
 
                             # For some resources, the name of the stream is the key for the child_paths
                             # but for others', the data_key contains the correct key
+                            child_key = child_endpoint_config.get('parent_subresource_key', child_endpoint_config.get('data_key'))
+
                             child_path = child_paths.get(child_stream_name,
-                                                         child_paths.get(child_endpoint_config.get('data_key', None)))
+                                                         child_paths.get(child_key))
 
                             child_bookmark_field = next(iter(child_endpoint_config.get(
                                 'replication_keys', [])), None)

--- a/tap_twilio/sync.py
+++ b/tap_twilio/sync.py
@@ -225,7 +225,7 @@ def sync_endpoint(
             # Need URL querystring for 1st page; subsequent pages provided by next_url
             # querystring: Squash query params into string
             querystring = None
-            if page == 1 and not params == {} and params is not None:
+            if page == 0 and not params == {} and params is not None:
                querystring = '&'.join(['%s=%s' % (key, value) for (key, value) in params.items()])
                # Replace <parent_id> in child stream params
                if parent_id:


### PR DESCRIPTION
## Problem

UsageTriggers and UsageRecords are currently listed in the streams.py, however they cannot be successfully retrieved as they have a non-standard setup in the api structure.

## Proposed changes

This change introduces the additional level of Usage to allow for retrieval or UsageRecords and UsageTriggers, allowing costs to be consumed.

This change also contains a bug fix for pagination which should benefit other subresources of Accounts


## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [ ] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions