### PR TITLE
Transform JSON strings to objects automatically

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,9 @@ jobs:
            pylint tap_twilio -d C,W,unexpected-keyword-arg,duplicate-code,too-many-arguments,too-many-locals,too-many-nested-blocks,useless-object-inheritance,no-self-argument,raising-non-exception,no-member
       - run:
           name: 'Unit Tests'
-          command: echo "No unit tests :("
+          command: |
+            . venv/bin/activate
+            pytest tests/unit
 
 workflows:
   version: 2

--- a/README.md
+++ b/README.md
@@ -409,4 +409,19 @@ To set up authentication simply include your Twilio `account_sid` and `auth_toke
    Messages are written to standard output following the Singer specification.
    The resultant stream of JSON data can be consumed by a Singer target.
 
+## To run tests
+
+1. Install python test dependencies in a virtual env and run nose unit and integration tests
+```
+  python3 -m venv venv
+  . venv/bin/activate
+  pip install --upgrade pip
+  pip install -e .[test]
+```
+
+2. To run unit tests:
+```
+  pytest tests/unit
+```
+
 ---

--- a/tap_twilio/schemas/chat_channels.json
+++ b/tap_twilio/schemas/chat_channels.json
@@ -35,7 +35,8 @@
     "attributes": {
       "type": [
         "null",
-        "string"
+        "object",
+        "array"
       ]
     },
     "type": {

--- a/tap_twilio/schemas/tasks.json
+++ b/tap_twilio/schemas/tasks.json
@@ -23,7 +23,8 @@
     "attributes": {
       "type": [
         "null",
-        "string"
+        "object",
+        "array"
       ]
     },
     "date_created": {

--- a/tap_twilio/schemas/workflows.json
+++ b/tap_twilio/schemas/workflows.json
@@ -17,7 +17,8 @@
     "configuration": {
       "type": [
         "null",
-        "string"
+        "object",
+        "array"
       ]
     },
     "date_created": {

--- a/tap_twilio/streams.py
+++ b/tap_twilio/streams.py
@@ -388,6 +388,7 @@ STREAMS = {
                 'key_properties': ['sid'],
                 'replication_method': 'INCREMENTAL',
                 'replication_keys': ['date_updated'],
+                'stringified_json_keys': ['attributes'],
                 'params': {},
                 'pagination': 'meta',
             },
@@ -468,6 +469,7 @@ STREAMS = {
                 'key_properties': ['sid'],
                 'replication_method': 'INCREMENTAL',
                 'replication_keys': ['date_updated'],
+                'stringified_json_keys': ['configuration'],
                 'params': {},
                 'pagination': 'meta',
             },
@@ -509,6 +511,7 @@ STREAMS = {
                 'key_properties': ['sid'],
                 'replication_method': 'INCREMENTAL',
                 'replication_keys': ['date_updated'],
+                'stringified_json_keys': ['attributes'],
                 'params': {},
                 'pagination': 'meta',
                 'children': {

--- a/tap_twilio/sync.py
+++ b/tap_twilio/sync.py
@@ -1,5 +1,6 @@
 import math
 from datetime import timedelta
+import sys
 
 import singer
 from singer import metrics, metadata, Transformer, utils
@@ -178,6 +179,7 @@ def sync_endpoint(
     bookmark_query_field_from = endpoint_config.get('bookmark_query_field_from')
     bookmark_query_field_to = endpoint_config.get('bookmark_query_field_to')
     data_key = endpoint_config.get('data_key', 'data')
+    stringified_json_keys = endpoint_config.get('stringified_json_keys')
     id_fields = endpoint_config.get('key_properties')
 
     start_window, end_window, date_window_days, now_datetime, last_datetime, max_bookmark_value = \
@@ -268,20 +270,20 @@ def sync_endpoint(
             data_dict = {}
             if data_key in data:
                 if isinstance(data[data_key], list):
-                    transformed_data = transform_json(data, data_key)
+                    transformed_data = transform_json(data, data_key, stringified_json_keys)
                 elif isinstance(data[data_key], dict):
                     data_list.append(data[data_key])
                     data_dict[data_key] = data_list
-                    transformed_data = transform_json(data_dict, data_key)
+                    transformed_data = transform_json(data_dict, data_key, stringified_json_keys)
             else:  # data_key not in data
                 if isinstance(data, list):
                     data_list = data
                     data_dict[data_key] = data_list
-                    transformed_data = transform_json(data_dict, data_key)
+                    transformed_data = transform_json(data_dict, data_key, stringified_json_keys)
                 elif isinstance(data, dict):
                     data_list.append(data)
                     data_dict[data_key] = data_list
-                    transformed_data = transform_json(data_dict, data_key)
+                    transformed_data = transform_json(data_dict, data_key, stringified_json_keys)
 
             # Process records and get the max_bookmark_value and record_count for the set of records
             if stream_name in selected_streams:

--- a/tap_twilio/transform.py
+++ b/tap_twilio/transform.py
@@ -24,10 +24,12 @@ def subresources_to_array(data_dict, data_key):
 def deserialise_jsons_in_dict(data_dict, jsons_keys):
     for jsons_key in jsons_keys:
         if jsons_key in data_dict:
-            try:
-                data_dict[jsons_key] = json.loads(data_dict[jsons_key])
-            except json.JSONDecodeError:
-                data_dict[jsons_key] = {'invalid_json': data_dict[jsons_key]}
+            # Deserialise only string types
+            if isinstance(data_dict[jsons_key], str):
+                try:
+                    data_dict[jsons_key] = json.loads(data_dict[jsons_key])
+                except json.JSONDecodeError:
+                    data_dict[jsons_key] = {'invalid_json': data_dict[jsons_key]}
 
     return data_dict
 

--- a/tests/unit/test_transform.py
+++ b/tests/unit/test_transform.py
@@ -106,58 +106,52 @@ def test_transform_list_with_jsons():
     data_dict = {
         'meta': 'foo',
         'my_data': [
+            # Stringified object should be converted to object
             {
                 'key1': '{"dummy": "foo1"}',
                 'key2': 'value1',
             },
-            {
-                'key1': '{"dummy": "foo2"}',
-                'key2': 'value2',
-            },
+            # Stringified array should be converted to list
             {
                 'key1': '[1, 2, 3, 4, 5]',
-                'key2': 'value3',
+                'key2': 'value2',
             },
             # Objects should remain object
             {
-                'key1': {"dummy": "foo4"},
-                'key2': 'value4',
+                'key1': {"dummy": "foo3"},
+                'key2': 'value3',
             },
             # List should remain list
             {
                 'key1': [1, 2, 3, 4, 5],
-                'key2': 'value5',
+                'key2': 'value4',
             },
             # Invalid JSON should be converted to valid JSON using a custom error structure
             {
-                'key1': 'THIS-IS-INVALID-JSON',
-                'key2': 'value6',
+                'key1': 'THIS IS AN INVALID JSON',
+                'key2': 'value5',
             }
         ]
     }
     assert transform_json(data_dict, data_key='my_data', jsons_keys=['key1']) == [
         {
-            'key1': {'dummy': "foo1"},
+            'key1': {'dummy': 'foo1'},
             'key2': 'value1',
         },
         {
-            'key1': {'dummy': 'foo2'},
+            'key1': [1, 2, 3, 4, 5],
             'key2': 'value2',
         },
         {
-            'key1': [1, 2, 3, 4, 5],
+            'key1': {'dummy': 'foo3'},
             'key2': 'value3',
         },
         {
-            'key1': {'dummy': 'foo4'},
+            'key1': [1, 2, 3, 4, 5],
             'key2': 'value4',
         },
         {
-            'key1': [1, 2, 3, 4, 5],
+            'key1': {'invalid_json': 'THIS IS AN INVALID JSON'},
             'key2': 'value5',
-        },
-        {
-            'key1': {'invalid_json': 'THIS-IS-INVALID-JSON'},
-            'key2': 'value6',
         }
     ]

--- a/tests/unit/test_transform.py
+++ b/tests/unit/test_transform.py
@@ -1,0 +1,114 @@
+"""
+Test transformations
+"""
+from tap_twilio.transform import deserialise_jsons_in_dict, transform_json
+
+
+def test_deserialise_jsons_in_dict():
+    """JSON strings in dictionary should be converted to objects"""
+    dict_with_json_string = {
+        'non-jsons': 1,
+        'jsons': '{"key1": "value1"}'
+    }
+    assert deserialise_jsons_in_dict(dict_with_json_string, ['jsons']) == {
+        'non-jsons': 1,
+        'jsons': {
+            'key1': 'value1'
+        }
+    }
+
+
+def test_deserialise_jsons_in_dict_with_wrong_key():
+    """JSON strings in dictionary should not be converted to objects if the key not exists"""
+    dict_with_json_string = {
+        'non-jsons': 1,
+        'jsons': '{"key1": "value1"}'
+    }
+    assert deserialise_jsons_in_dict(dict_with_json_string, ['NOT_EXISTING_KEY']) == {
+        'non-jsons': 1,
+        'jsons': '{"key1": "value1"}'
+    }
+
+
+def test_deserialise_jsons_in_dict_with_invalid_json_string():
+    """Invalid JSON strings in dictionary should be converted to objects with the original string"""
+    dict_with_json_string = {
+        'non-jsons': 1,
+        'jsons': 'THIS IS AN INVALID JSON'
+    }
+    assert deserialise_jsons_in_dict(dict_with_json_string, ['jsons']) == {
+        'non-jsons': 1,
+        'jsons': {
+            'invalid_json': 'THIS IS AN INVALID JSON'
+        }
+    }
+
+
+def test_deserialise_jsons_in_dict_with_multiple_keys():
+    """JSON strings in dictionary should NOT be converted to objects if the key not exists"""
+    dict_with_json_string = {
+        'non-jsons': 1,
+        'jsons_with_object': '{"key1": "value1"}',
+        'jsons_with_array': '[1, 2, 3, 4, 5]'
+    }
+    assert deserialise_jsons_in_dict(dict_with_json_string, ['jsons_with_object', 'jsons_with_array']) == {
+        'non-jsons': 1,
+        'jsons_with_object': {
+            'key1': 'value1'
+        },
+        'jsons_with_array': [1, 2, 3, 4, 5]
+    }
+
+
+def test_transform_list_of_dicts():
+    """Every dictionary item should be transformed"""
+    data_dict = {
+        'meta': 'foo',
+        'my_data': [
+            {
+                'key_1': 'value_1',
+                'key_2': 'value_2',
+            },
+            {
+                'key_1': 'value_3',
+                'key_2': 'value_4',
+            }
+        ]
+    }
+    assert transform_json(data_dict, data_key='my_data', jsons_keys=None) == [
+        {
+            'key_1': 'value_1',
+            'key_2': 'value_2',
+        },
+        {
+            'key_1': 'value_3',
+            'key_2': 'value_4',
+        }
+    ]
+
+
+def test_transform_list_with_jsons():
+    """JSON strings in every dictionary item should be transformed to objects"""
+    data_dict = {
+        'meta': 'foo',
+        'my_data': [
+            {
+                'key1': '{"dummy": "foo1"}',
+                'key2': 'value2',
+            },
+            {
+                'key1': '{"dummy": "foo2"}',
+                'key2': 'value4',
+            }
+        ]
+    }
+    assert transform_json(data_dict, data_key='my_data', jsons_keys=['key1']) == [
+        {
+            'key1': {'dummy': "foo1"},
+            'key2': 'value2',
+        },
+        {
+            'key1': {'dummy': 'foo2'},
+            'key2': 'value4',
+        }
+    ]

--- a/tests/unit/test_transform.py
+++ b/tests/unit/test_transform.py
@@ -44,6 +44,20 @@ def test_deserialise_jsons_in_dict_with_invalid_json_string():
     }
 
 
+def test_deserialise_jsons_in_dict_with_objects():
+    """JSON string keys which already objects should remain objects"""
+    dict_with_json_string = {
+        'non-jsons': 1,
+        'jsons': {'hey': 'this is already an object already'}
+    }
+    assert deserialise_jsons_in_dict(dict_with_json_string, ['jsons']) == {
+        'non-jsons': 1,
+        'jsons': {
+            'hey': 'this is already an object already'
+        }
+    }
+
+
 def test_deserialise_jsons_in_dict_with_multiple_keys():
     """JSON strings in dictionary should NOT be converted to objects if the key not exists"""
     dict_with_json_string = {
@@ -94,21 +108,56 @@ def test_transform_list_with_jsons():
         'my_data': [
             {
                 'key1': '{"dummy": "foo1"}',
-                'key2': 'value2',
+                'key2': 'value1',
             },
             {
                 'key1': '{"dummy": "foo2"}',
+                'key2': 'value2',
+            },
+            {
+                'key1': '[1, 2, 3, 4, 5]',
+                'key2': 'value3',
+            },
+            # Objects should remain object
+            {
+                'key1': {"dummy": "foo4"},
                 'key2': 'value4',
+            },
+            # List should remain list
+            {
+                'key1': [1, 2, 3, 4, 5],
+                'key2': 'value5',
+            },
+            # Invalid JSON should be converted to valid JSON using a custom error structure
+            {
+                'key1': 'THIS-IS-INVALID-JSON',
+                'key2': 'value6',
             }
         ]
     }
     assert transform_json(data_dict, data_key='my_data', jsons_keys=['key1']) == [
         {
             'key1': {'dummy': "foo1"},
-            'key2': 'value2',
+            'key2': 'value1',
         },
         {
             'key1': {'dummy': 'foo2'},
+            'key2': 'value2',
+        },
+        {
+            'key1': [1, 2, 3, 4, 5],
+            'key2': 'value3',
+        },
+        {
+            'key1': {'dummy': 'foo4'},
             'key2': 'value4',
+        },
+        {
+            'key1': [1, 2, 3, 4, 5],
+            'key2': 'value5',
+        },
+        {
+            'key1': {'invalid_json': 'THIS-IS-INVALID-JSON'},
+            'key2': 'value6',
         }
     ]


### PR DESCRIPTION
## Problem

The Twilio API sends some stream properties as stringified JSON messages:
* `chat_channels.attributes`
* `tasks.attributes`
* `workflows.configuration`

Currently the tap sends these stream attributres as strings and singer/PPW targets are loading them into `VARCHAR` columns according to the schema.

This PR converts these JSON strings to python objects and sending to target as objects so the target can load it into semi-structured optimised column types like `VARIANT` in case of target-snowflake or `JSONB` in case of target-postgres.

## Proposed changes

The PR adds two changes:
* Changing the [stream schemas](https://github.com/transferwise/pipelinewise-tap-twilio/pull/20/files#diff-6ae95c3f6d8033acd4368985c3e92b4cb501c7409ca32b64ab5d162dc3d8c51b) from `string` to accept `object` and `array`. Array is required as well because not every valid JSON deserialised to python dict types. JSON arrays are serialised into python list types and we need to accept both to have full JSON support.
* Adding an extra `stringified_json_keys` key to the [streams.py](https://github.com/transferwise/pipelinewise-tap-twilio/pull/20/files#diff-b6548f82f9f755c2816e8a7a9e76a038ceb06fa534cfa023535f81669e90b189) This new item is a list of keys in the received API response that will be converted to python dict or list automatically.

Preparing for errors:

1. If the twilio API sends invalid JSON strings then the data will be stored in a specific data structure:
```
{
  'invalid_json': 'the-original-message-from-twilio-api'
}
```

2. If the twilio API sends a real JSON instead of the expected stringified JSON, then it will not try to de-serialise it but will keep the original object as it received from the API.

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions